### PR TITLE
Fix npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "index.d.ts"
   ],
   "scripts": {
-    "prepublishOnly:": "npm run build",
+    "prepublishOnly": "npm run build",
     "build": "babel -o ignore.js index.js",
     "test": "npm run build && nyc ava ./test/ignore.js"
   },


### PR DESCRIPTION
Change-type: patch

Publishing to the npm registry is broken because of a typo in the `package.json` `prepublishOnly` script, which causes `npm run build` to be skipped and the published package to be missing files:
```
$ node
> require('@balena/dockerignore')
Uncaught:
Error: Cannot find module 'balena-cli/node_modules/@balena/dockerignore/ignore.js'. Please verify that the package.json has a valid "main" entry
...
```